### PR TITLE
cmux: fix deprecated `depends_on macos:` string comparison

### DIFF
--- a/Casks/cmux.rb
+++ b/Casks/cmux.rb
@@ -12,7 +12,7 @@ cask "cmux" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "cmux.app"
   binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"


### PR DESCRIPTION
## What

Replace the deprecated string-comparison form of `depends_on macos:` with the symbol form:

```diff
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
```

## Why

Recent Homebrew prints this on every `brew update` / `brew upgrade`:

> Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sonoma` instead.
> Please report this issue to the manaflow-ai/homebrew-cmux tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
>   /opt/homebrew/Library/Taps/manaflow-ai/homebrew-cmux/Casks/cmux.rb:15

A bare `:sonoma` symbol already means "Sonoma or newer", so this keeps the exact same minimum-version requirement while clearing the warning.

## Testing

`brew style Casks/cmux.rb` no longer reports the deprecation. (Two unrelated pre-existing style offenses — `Cask/Desc` and `HomepageUrlStyling` — are left untouched to keep this PR focused.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/homebrew-cmux/pr/3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783912502&installation_id=133855650&pr_number=3&repository=manaflow-ai%2Fhomebrew-cmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fhomebrew-cmux%2Fpull%2F3&signature=64df538b8f6580a126a86d9933c03aedbd2856b9e8f3a57cc43517fa32e4cf96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `cmux` cask to use the symbol form for `depends_on macos:`. This removes the deprecation warning on `brew update`/`brew upgrade` and keeps the Sonoma or newer requirement.

<sup>Written for commit 191a6f35b2ed1de36b40b9e7715bb45d8080afb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/homebrew-cmux/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cmux macOS system requirement to target macOS Sonoma specifically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #2
