### PR TITLE
cmux: add `auto_updates true`

### DIFF
--- a/Casks/cmux.rb
+++ b/Casks/cmux.rb
@@ -12,6 +12,7 @@ cask "cmux" do
     strategy :github_latest
   end
 
+  auto_updates true
   depends_on macos: ">= :sonoma"
 
   app "cmux.app"


### PR DESCRIPTION
## What

```diff
   livecheck do
     url :url
     strategy :github_latest
   end

+  auto_updates true
   depends_on macos: ...
```

## Why

cmux ships a built-in [Sparkle](https://sparkle-project.org/) auto-updater — there's a dedicated `Packages/CmuxUpdater/` module and an `SUFeedURL` appcast in `Resources/Info.plist` over in [manaflow-ai/cmux](https://github.com/manaflow-ai/cmux). The app keeps itself up to date.

Without an `auto_updates true` stanza the cask looks like an ordinary fully-Homebrew-managed cask, so `brew upgrade` re-installs cmux every time the tap `version` moves — fighting the in-app updater:

```
==> Upgrading cmux
  0.63.2 -> 0.64.15
==> Removing App '/Applications/cmux.app'
==> Moving App 'cmux.app' to '/Applications/cmux.app'
🍺  cmux was successfully upgraded!
```

Declaring `auto_updates true` lets Homebrew defer to Sparkle and brings cmux in line with the self-updating-cask controls introduced in Homebrew 6.0 ([Homebrew/brew#21882](https://github.com/Homebrew/brew/issues/21951)) — `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS=1` to skip it, `--greedy`/`--greedy-auto-updates` to force it — none of which apply to cmux today.

## Testing

`brew style Casks/cmux.rb` introduces no new offenses. (The remaining pre-existing `Cask/Desc`, `HomepageUrlStyling` and `OSDependsOn` offenses are untouched here; the `depends_on` one is addressed in #3.)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/homebrew-cmux/pr/5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783913340&installation_id=133855650&pr_number=5&repository=manaflow-ai%2Fhomebrew-cmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fhomebrew-cmux%2Fpull%2F5&signature=7f053c2c314374383ff3a15e752b7a7e6d52242b979eadcc8e66c2c3a9c03e91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `auto_updates true` to the `cmux` cask so Homebrew defers to the app’s Sparkle updater and stops reinstalling on `brew upgrade`. This aligns the cask with Homebrew 6.0 self-updating behavior and avoids unnecessary downloads.

<sup>Written for commit f6226cea1da96aa5d7195337c801b02722183638. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/homebrew-cmux/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

