### PR TITLE
Fix cask macOS dependency syntax

### DIFF
--- a/Casks/cmux.rb
+++ b/Casks/cmux.rb
@@ -12,7 +12,7 @@ cask "cmux" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "cmux.app"
   binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"


### PR DESCRIPTION
## Summary
- Replace deprecated string comparison syntax for the cmux cask macOS dependency
- Use the current Homebrew Cask symbol form: `depends_on macos: :sonoma`

## Validation
- `brew info --cask manaflow-ai/cmux/cmux` loads without the deprecation warning
- `brew outdated --cask cmux` emits no syntax warning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the deprecated macOS requirement syntax in the `cmux` cask with the supported symbol form. This removes the deprecation warning and cleanly enforces a minimum of macOS Sonoma.

<sup>Written for commit a3283e593a6b259db72438637e44982ffd85af91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/homebrew-cmux/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS system requirements to explicitly require macOS Sonoma.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->