### PR TITLE
cmux: use symbol form for depends_on macos (silence deprecation)

### DIFF
--- a/Casks/cmux.rb
+++ b/Casks/cmux.rb
@@ -12,7 +12,7 @@ cask "cmux" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "cmux.app"
   binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"


### PR DESCRIPTION
## What

Change `depends_on macos: ">= :sonoma"` → `depends_on macos: :sonoma` in `Casks/cmux.rb`.

## Why

The string-comparison form is deprecated in current Homebrew and prints this warning on **every** `brew` command that evaluates the cask (install, upgrade, update, cleanup):

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated!
Use `depends_on macos: :sonoma` instead.
Please report this issue to the manaflow-ai/homebrew-cmux tap ...
 /opt/homebrew/Library/Taps/manaflow-ai/homebrew-cmux/Casks/cmux.rb:15
```

The symbol form `:sonoma` already means "Sonoma or newer", so this is behaviorally identical — it just silences the warning.

## Test

`brew style` / `brew audit --cask` on the edited cask no longer emits the deprecation warning.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/homebrew-cmux/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785157508&installation_id=133855650&pr_number=7&repository=manaflow-ai%2Fhomebrew-cmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fhomebrew-cmux%2Fpull%2F7&signature=45fab9a12a1f5e1c2a7b7c7550a0b905f186dc53125b0617537dd42f97a5284d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `cmux` cask to use `depends_on macos: :sonoma` instead of the deprecated string comparison, removing the deprecation warning on every `brew` run. Behavior stays the same (Sonoma or newer).

<sup>Written for commit 67580ee637370464be31125028669cf5f73b8496. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/homebrew-cmux/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS requirement for the `cmux` Homebrew cask to use the latest Sonoma compatibility declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->