### PR TITLE
cmux: fix deprecated depends_on macos string comparison format

### DIFF
--- a/Casks/cmux.rb
+++ b/Casks/cmux.rb
@@ -12,7 +12,7 @@ cask "cmux" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "cmux.app"
   binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"


### PR DESCRIPTION
Fix deprecation warning when installing cmux:

```
Warning: Calling string comparison format for  is deprecated! Use  instead.
```

Changed `depends_on macos: ">= :sonoma"` → `depends_on macos: :sonoma`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/homebrew-cmux/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786170184&installation_id=133855650&pr_number=8&repository=manaflow-ai%2Fhomebrew-cmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fhomebrew-cmux%2Fpull%2F8&signature=2caa250f411b7135198624de099cf8c426801436a78c25429271c8d5d1412ba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix deprecation warning when installing `cmux` by updating the cask's macOS requirement. Replaced `depends_on macos: ">= :sonoma"` with `depends_on macos: :sonoma`.

<sup>Written for commit 875f10d3791ab1fd997d9c7b918340f64149c706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/homebrew-cmux/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS compatibility requirement for the `cmux` cask to use the current Sonoma dependency format, improving install behavior on supported systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->